### PR TITLE
コードシンタックスの行番号の最終行に改行を追加するように変更 (#145)

### DIFF
--- a/src/content_scripts/article/show-line-number-content.js
+++ b/src/content_scripts/article/show-line-number-content.js
@@ -9,8 +9,7 @@ export default class ShowLineNumberContent {
     const codeFrames = handler.getCodeFrames();
 
     for (let codeFrame of codeFrames) {
-      const rows = codeFrame.codeText.split('\n');
-      const length = rows.length;
+      const length = codeFrame.codeElement.textContent.split(/\n/).length - 1;
       let numbers = document.createElement('pre');
       numbers.className = 'qa-khsk-codeNumber';
       for (let i = 0; i < length; ++i) {
@@ -18,9 +17,6 @@ export default class ShowLineNumberContent {
 
         let label = document.createElement('span');
         label.innerHTML = number + '\n'; // Textでは改行が反映されない
-        if (i + 1 === length) {
-          label.innerHTML += '\n'; // 最終行には改行が追加されるqiitaの仕様に合わせる
-        }
         label.dataset.lineNumber = i + 1;
 
         numbers.appendChild(label);

--- a/src/content_scripts/article/show-line-number-content.js
+++ b/src/content_scripts/article/show-line-number-content.js
@@ -18,6 +18,9 @@ export default class ShowLineNumberContent {
 
         let label = document.createElement('span');
         label.innerHTML = number + '\n'; // Textでは改行が反映されない
+        if (i + 1 === length) {
+          label.innerHTML += '\n'; // 最終行には改行が追加されるqiitaの仕様に合わせる
+        }
         label.dataset.lineNumber = i + 1;
 
         numbers.appendChild(label);


### PR DESCRIPTION
コードシンタックスが複数行だった場合に行番号とコード側でコードシンタックス向けの背景色の位置がずれていたため、ズレを無くすために行番号側にも改行を追加してみました。
よろしくお願いします。

<img width="891" alt="aaascala___playframework_ mac __-_qiita" src="https://cloud.githubusercontent.com/assets/2158863/21875002/f9d2eed6-d8bb-11e6-8437-01bfb4f03704.png">


<img width="1034" alt="scala___playframework_ mac __-_qiita" src="https://cloud.githubusercontent.com/assets/2158863/21875004/fb86cc3e-d8bb-11e6-9c65-636b7f118cb6.png">


**環境**

- **Q Accelerator Version: 1.0.0**
- **Chrome Version: 55.0.2883.95 (64-bit)**
