### PR TITLE
fix: 不具合 > 数式表示時に左側に数字(例: 1234...)が表示される #171

### DIFF
--- a/src/content_scripts/article/show-line-number-content.js
+++ b/src/content_scripts/article/show-line-number-content.js
@@ -7,8 +7,13 @@ export default class ShowLineNumberContent {
 
     const handler = new ArticleDomHandler();
     const codeFrames = handler.getCodeFrames();
+    const ignoreLangueges = ['math'];
 
     for (let codeFrame of codeFrames) {
+      if (ignoreLangueges.includes(codeFrame.dataLang.toLowerCase())) {
+        continue;
+      }
+
       const length = codeFrame.codeElement.textContent.split(/\n/).length - 1;
       let numbers = document.createElement('pre');
       numbers.className = 'qa-khsk-codeNumber';


### PR DESCRIPTION
“math”を除外対象に設定。
今後増えたらignoreLanguegesに追加する。

