### PR TITLE
Update stock count using API v2

### DIFF
--- a/src/content_scripts/article/show-stock-counts-content.js
+++ b/src/content_scripts/article/show-stock-counts-content.js
@@ -15,9 +15,9 @@ export default class ShowStockCountsContent {
       // プライベート記事はストック不可なので不要
       if (itemKind === 'private') return;
 
-      axios.get(`https://qiita.com/api/v1/items/${itemId}`)
+      axios.get(`https://qiita.com/api/v2/items/${itemId}/stockers?per_page=100`)
       .then(response => {
-        handler.prependCountToStock(response.data.stock_count);
+        handler.prependCountToStock(response.data.length >= 100 ? '100+' : response.data.length);
       })
       .catch(error => {
         Util.infoLog('ストック数を表示', error.response.data.error);


### PR DESCRIPTION
### Description

#178 に書かれているAPI v1の配信に伴ってストック数が取得できなくなっていたため、ひとまずは一度のAPIコールで取得できる範囲でストックを表示するように更新しました。

100 overであるかどうかとなると二回目のAPIコールが発生するため、ここでは100以上として表すことができる100+表記を用いています。