### PR TITLE
ヘッダー固定機能を追加

### DIFF
--- a/src/content_scripts/article-content.js
+++ b/src/content_scripts/article-content.js
@@ -1,6 +1,7 @@
 import Util from '../common/util';
 import AutoLikeContent from './article/auto-like-content.js';
 import CopyCodeContent from './article/copy-code-content.js';
+import FixHeader from './article/fix-header.js';
 import MuteUserArticleContent from './article/mute-user-article-content.js';
 import MuteUserCommentContent from './article/mute-user-comment-content.js';
 import SaveHisotoryContent from './article/save-history.js';
@@ -71,6 +72,14 @@ Util.getSettings(settings => {
   try {
     if (settings['show-line-number']) {
       new ShowLineNumberContent().run();
+    }
+  } catch (e) {
+    Util.errorLog(e);
+  }
+
+  try {
+    if (settings['fix-header']) { //FIXME: 実際の設定値を使用するように書き換えてください。
+      new FixHeader().run();
     }
   } catch (e) {
     Util.errorLog(e);

--- a/src/content_scripts/article-list-stream-content.js
+++ b/src/content_scripts/article-list-stream-content.js
@@ -7,6 +7,7 @@
  */
 
 import Util from '../common/util';
+import FixHeader from './article-list-stream/fix-header.js';
 import MuteUserArticleListStreamContent from './article-list-stream/mute-user-article-list-stream-content.js';
 
 Util.getSettings(settings => {
@@ -14,6 +15,14 @@ Util.getSettings(settings => {
   try {
     if (settings['mute-users'] && settings['mute-user-article']) {
       new MuteUserArticleListStreamContent().run(settings['mute-users']);
+    }
+  } catch (e) {
+    Util.errorLog(e);
+  }
+
+  try {
+    if (settings['fix-header']) { //FIXME: 実際の設定値を使用するように書き換えてください。
+      new FixHeader().run();
     }
   } catch (e) {
     Util.errorLog(e);

--- a/src/content_scripts/article-list-stream/fix-header.css
+++ b/src/content_scripts/article-list-stream/fix-header.css
@@ -1,0 +1,5 @@
+.st-HeaderContainer {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}

--- a/src/content_scripts/article-list-stream/fix-header.js
+++ b/src/content_scripts/article-list-stream/fix-header.js
@@ -1,0 +1,10 @@
+import Util from '../../common/util';
+
+export default class FixHeader {
+
+  run() {
+    require('style-loader!./fix-header.css');
+    Util.infoLog('ヘッダーを固定');
+  }
+
+}

--- a/src/content_scripts/article-list-tags-content.js
+++ b/src/content_scripts/article-list-tags-content.js
@@ -4,6 +4,7 @@
  */
 
 import Util from '../common/util';
+import FixHeader from './article-list-tags/fix-header.js';
 import MuteUserArticleListTagsContent from './article-list-tags/mute-user-article-list-tags-content.js';
 
 Util.getSettings(settings => {
@@ -11,6 +12,14 @@ Util.getSettings(settings => {
   try {
     if (settings['mute-users'] && settings['mute-user-article']) {
       new MuteUserArticleListTagsContent().run(settings['mute-users']);
+    }
+  } catch (e) {
+    Util.errorLog(e);
+  }
+
+  try {
+    if (settings['fix-header']) { //FIXME: 実際の設定値を使用するように書き換えてください。
+      new FixHeader().run();
     }
   } catch (e) {
     Util.errorLog(e);

--- a/src/content_scripts/article-list-tags/fix-header.css
+++ b/src/content_scripts/article-list-tags/fix-header.css
@@ -1,0 +1,5 @@
+.st-HeaderContainer {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}

--- a/src/content_scripts/article-list-tags/fix-header.js
+++ b/src/content_scripts/article-list-tags/fix-header.js
@@ -1,0 +1,10 @@
+import Util from '../../common/util';
+
+export default class FixHeader {
+
+  run() {
+    require('style-loader!./fix-header.css');
+    Util.infoLog('ヘッダーを固定');
+  }
+
+}

--- a/src/content_scripts/article/fix-header.css
+++ b/src/content_scripts/article/fix-header.css
@@ -1,0 +1,13 @@
+.st-HeaderContainer {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
+.p-items_toc {
+  top: 56px;
+}
+
+.it-ActionsMobile {
+  top: calc(56px + 10px);
+}

--- a/src/content_scripts/article/fix-header.js
+++ b/src/content_scripts/article/fix-header.js
@@ -1,0 +1,10 @@
+import Util from '../../common/util';
+
+export default class FixHeader {
+
+  run() {
+    require('style-loader!./fix-header.css');
+    Util.infoLog('ヘッダーを固定');
+  }
+
+}

--- a/src/content_scripts/top-content.js
+++ b/src/content_scripts/top-content.js
@@ -1,0 +1,21 @@
+/**
+ * 以下のURLで発火
+ * http://qiita.com/trend
+ * http://qiita.com/timeline
+ * http://qiita.com/tag-feed
+ */
+
+import Util from '../common/util';
+import FixHeader from './top/fix-header.js';
+
+Util.getSettings(settings => {
+
+  try {
+    if (settings['fix-header']) { //FIXME: 実際の設定値を使用するように書き換えてください。
+      new FixHeader().run();
+    }
+  } catch (e) {
+    Util.errorLog(e);
+  }
+
+});

--- a/src/content_scripts/top/fix-header.css
+++ b/src/content_scripts/top/fix-header.css
@@ -1,0 +1,9 @@
+div[data-hyperapp-app="GlobalHeader"] {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
+.p-home_menu {
+  top: 56px;
+}

--- a/src/content_scripts/top/fix-header.js
+++ b/src/content_scripts/top/fix-header.js
@@ -1,0 +1,10 @@
+import Util from '../../common/util';
+
+export default class FixHeader {
+
+  run() {
+    require('style-loader!./fix-header.css');
+    Util.infoLog('ヘッダーを固定');
+  }
+
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -61,6 +61,17 @@
         "https://qiita.com/drafts/new"
       ],
       "js": ["content_scripts/drafts-new-content.js"]
+    },
+    {
+      "matches": [
+        "http://qiita.com/trend",
+        "https://qiita.com/trend",
+        "http://qiita.com/timeline",
+        "https://qiita.com/timeline",
+        "http://qiita.com/tag-feed",
+        "https://qiita.com/tag-feed"
+      ],
+      "js": ["content_scripts/top-content.js"]
     }
   ],
   "permissions": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
     'content_scripts/article-list-tags-content': CONTENT_SCRIPTS_DIR + 'article-list-tags-content.js',
     'content_scripts/drafts-new-content': CONTENT_SCRIPTS_DIR + 'drafts-new-content.js',
     'content_scripts/popular-items-content': CONTENT_SCRIPTS_DIR + 'popular-items-content.js',
+    'content_scripts/top-content': CONTENT_SCRIPTS_DIR + 'top-content.js',
     'js/settings': COMPONENTS_DIR + 'settings.js' // components/settings.js -> js/settings.js
   },
   output: {


### PR DESCRIPTION
fix #185 
ひとまずコンテンツスクリプトのみを実装しました。
当初はスクリプトで動的にスタイルを書き換える方式にしようとしましたが、トップページでページを切り替える際にHyperappによってDOMが書き換えられてしまいうまく動作しないため、CSSを読み込む方式にしました。
レビューをお願いいたします。