### PR TITLE
ヘッダー固定用の正規表現を修正

### DIFF
--- a/src/content_scripts/all/fix-header.js
+++ b/src/content_scripts/all/fix-header.js
@@ -1,6 +1,6 @@
 import Util from '../../common/util';
 
-const URL_PATTERN_TOP = new RegExp('^https?://qiita\\.com/(trend|timeline|tag-feed)$');
+const URL_PATTERN_TOP = new RegExp('^https?://qiita\\.com/(|timeline|tag-feed|milestones)$');
 const URL_PATTERN_ARTICLE = new RegExp('^https?://qiita\\.com/[^/]+/(items|private)/[^/#?]+$');
 
 export default class FixHeader {


### PR DESCRIPTION
いつからかトップページのURLに/trendがつかなくなり
付けてもリダイレクトされるのでtrendを削除し
新しくできたマイルストーン(/milestones)を追加